### PR TITLE
Correção e atualização do léxico para a v3

### DIFF
--- a/src/quase.sable
+++ b/src/quase.sable
@@ -8,7 +8,7 @@ Helpers
     inteiro_binario = '0b' ('0' | '1')+;
     inteiro_decimal = digito+;
     real_decimal = inteiro_decimal '.' inteiro_decimal;
-    real_cientifico = inteiro_decimal ('e' | 'E') inteiro_decimal;
+    real_cientifico = ['1'..'9'] ('.' inteiro_decimal)? ('e' | 'E') '-'? inteiro_decimal;
  
 Tokens
     e_comercial = '&';

--- a/src/quase.sable
+++ b/src/quase.sable
@@ -4,7 +4,6 @@ Helpers
     letra_minuscula = ['a'..'z'];
     letra_maiuscula = ['A'..'Z'];
     letra = letra_minuscula | letra_maiuscula;
-    sinal = ('+' | '-');
     digito = ['0'..'9'];
     inteiro_binario = '0b' ('0' | '1')+;
     inteiro_decimal = digito+;
@@ -55,8 +54,8 @@ Tokens
     id = letra (letra | '_')*;
     cid = '_' (letra | '_')*;
 
-    numero_inteiro = sinal? inteiro_binario | sinal? inteiro_decimal;
-    numero_real = sinal? real_decimal | sinal? real_cientifico;
+    numero_inteiro = inteiro_binario | inteiro_decimal;
+    numero_real = real_decimal | real_cientifico;
 
     vazio = (' ' | 9 | 10 | 13)+;
 

--- a/src/quase.sable
+++ b/src/quase.sable
@@ -1,8 +1,8 @@
 Package quase;
 
 Helpers
-    letra_minuscula = ['a'..'z'];
-    letra_maiuscula = ['A'..'Z'];
+    letra_minuscula = ['a'..'z'] | [224..227] | 231 | 233 | 234 | 237 | [243..245] | 250;
+    letra_maiuscula = ['A'..'Z'] | [192..195] | 199 | 201 | 202 | 205 | [211..213] | 218;
     letra = letra_minuscula | letra_maiuscula;
     digito = ['0'..'9'];
     inteiro_binario = '0b' ('0' | '1')+;

--- a/src/quase.sable
+++ b/src/quase.sable
@@ -12,54 +12,53 @@ Helpers
     real_cientifico = inteiro_decimal ('e' | 'E') inteiro_decimal;
  
 Tokens
-	e_comercial = '&';
-	ponto_virgula = ';';
-	classe = 'classe';
-	filha_da_classe = 'filha da classe';
-	comeca = 'começa';
-	termina = 'termina';
-	objeto = 'objeto';
-	virgula = ',';
-	variavel = 'var';
-	constante = 'cons';
-	inicializacao = ':=';
-	int = 'int';
-	bool = 'bool';
-	real = 'real';
-	ponto_de_entrada = '=>';
-	procedimento = 'procedimento';
-	parenteses_esquerdo = '(';
-	parenteses_direito = ')';
-	funcao = 'função';
-	se = 'se';
-	senao = 'senão';
-	enquanto = 'enquanto';
-	atribuicao = '=';
-	ponto = '.';
-	true = 'true';
-	false = 'false';
-	subtracao = '-';
-	entao = 'então';
-	adicao = '+';
-	multiplicacao = '*';
-	divisao = '/';
-	modulo = '%';
-	igualdade = '==';
-	menor_que = '<';
-	negacao = '!';
-	e = 'e';
-	ou = 'ou';
+    e_comercial = '&';
+    ponto_virgula = ';';
+    classe = 'classe';
+    filha_da_classe = 'filha da classe';
+    comeca = 'começa';
+    termina = 'termina';
+    objeto = 'objeto';
+    virgula = ',';
+    variavel = 'var';
+    constante = 'cons';
+    inicializacao = ':=';
+    int = 'int';
+    bool = 'bool';
+    real = 'real';
+    ponto_de_entrada = '=>';
+    procedimento = 'procedimento';
+    parenteses_esquerdo = '(';
+    parenteses_direito = ')';
+    funcao = 'função';
+    se = 'se';
+    senao = 'senão';
+    enquanto = 'enquanto';
+    atribuicao = '=';
+    ponto = '.';
+    true = 'true';
+    false = 'false';
+    subtracao = '-';
+    entao = 'então';
+    adicao = '+';
+    multiplicacao = '*';
+    divisao = '/';
+    modulo = '%';
+    igualdade = '==';
+    menor_que = '<';
+    negacao = '!';
+    e = 'e';
+    ou = 'ou';
 
-	comentario = '{' ([0..124] | 126 | 127)* '}';
+    comentario = '{' ([0..124] | 126 | 127)* '}';
 
     id = letra (letra | '_')*;
     cid = '_' (letra | '_')*;
-    
+
     numero_inteiro = sinal? inteiro_binario | sinal? inteiro_decimal;
     numero_real = sinal? real_decimal | sinal? real_cientifico;
-    
+
     vazio = (' ' | 9 | 10 | 13)+;
-	
+
 Ignored Tokens
-	comentario, vazio;
-	
+    comentario, vazio;


### PR DESCRIPTION
Corrigidas as expressões regulares dos números. A representação de números negativos passou para a produção exp => '-' exp e a notação científica está implementada baseada na definição da Wikipédia.

Adicionado suporte à caracteres do padrão brasileiro. Foram considerados os caracteres: ÁÉÍÓÚÀÂÊÔÇáéíóúàâêôç.